### PR TITLE
feat(user): add email duplicate confirmation API

### DIFF
--- a/src/user/dto/email-check.dto.ts
+++ b/src/user/dto/email-check.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString } from 'class-validator';
+
+export class EmailCheckDto {
+  @IsString()
+  @IsEmail()
+  @ApiProperty({ description: '이메일' })
+  email: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,8 +1,18 @@
-import { Body, Controller, HttpStatus, Post, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Query,
+  Res,
+} from '@nestjs/common';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { json } from 'stream/consumers';
 import { CreateUserDto } from './dto/create-user.dto';
+import { EmailCheckDto } from './dto/email-check.dto';
 import { UserService } from './user.service';
 
 @Controller('user')
@@ -12,12 +22,25 @@ export class UserController {
 
   @Post('')
   @ApiOperation({
-    summary: '유저 조회 API',
-    description: '유저의 정보를 조회한다.',
+    summary: '유저 생성 API',
+    description: '유저를 생성한다.',
   })
-  @ApiCreatedResponse({ description: '유저의 정보를 조회한다.', type: json })
+  @ApiCreatedResponse({ description: '유저를 생성한다.', type: json })
   async getUser(@Body() requestDto: CreateUserDto, @Res() res: Response) {
     const user = await this.userService.createUser(requestDto);
     return res.status(HttpStatus.CREATED).json(user);
+  }
+
+  @Get('emailCheck')
+  @ApiOperation({
+    summary: '이메일 중복 확인 API',
+    description: '이메일 중복 확인',
+  })
+  @ApiCreatedResponse({
+    description: '회원가입시 이메일 중복 확인',
+    type: json,
+  })
+  async emailCheck(@Query() emailCheckDto: EmailCheckDto) {
+    return await this.userService.emailCheck(emailCheckDto);
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,8 +1,14 @@
-import { ForbiddenException, HttpStatus, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { hash } from 'bcrypt';
 import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
+import { EmailCheckDto } from './dto/email-check.dto';
 import { User } from './entities/user.entity';
 
 @Injectable()
@@ -22,7 +28,7 @@ export class UserService {
     if (isExist) {
       throw new ForbiddenException({
         statusCode: HttpStatus.FORBIDDEN,
-        message: ['Already registered userId'],
+        message: ['Already registered email'],
         error: 'Forbidden',
       });
     }
@@ -30,6 +36,28 @@ export class UserService {
     requestDto.password = await hash(requestDto.password, 10); // FIX ME : use env
 
     const { password, ...result } = await this.userRepository.save(requestDto);
+    return result;
+  }
+
+  async emailCheck(emailCheckDto: EmailCheckDto) {
+    if (!emailCheckDto.email) {
+      throw new BadRequestException({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ['Invalid value'],
+        error: 'Bad Request',
+      });
+    }
+
+    const isExist = await this.userRepository.findOneBy({
+      email: emailCheckDto.email,
+    });
+
+    const result = {};
+    if (isExist) {
+      result['isValidEmail'] = false;
+    } else {
+      result['isValidEmail'] = true;
+    }
     return result;
   }
 }


### PR DESCRIPTION
# 📝 Description
회원가입 시 이메일 중복 확인 API를 추가하였습니다.

# 💻 How To Test
중복 이메일이 있을 경우
![image](https://user-images.githubusercontent.com/89819254/197935623-047d856b-3106-48e0-9adc-99050bce27b1.png)

중복 이메일이 없을 경우 (이메일 사용 가능)
![image](https://user-images.githubusercontent.com/89819254/197935628-8577c979-845a-4354-acc4-6e1d3044fa9a.png)

이메일 형식이 아닐 경우
![image](https://user-images.githubusercontent.com/89819254/197935636-33d3d149-f71e-4549-a493-11a5f1975589.png)
